### PR TITLE
Add CLI utility to run project stages

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,40 @@
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_script(script_name: str) -> None:
+    """Запускает указанный скрипт в отдельном процессе."""
+    script_path = Path(__file__).resolve().parent / script_name
+    if not script_path.exists():
+        raise FileNotFoundError(f"Не найден скрипт: {script_path}")
+    subprocess.run([sys.executable, str(script_path)], check=True)
+
+
+def main() -> None:
+    """Точка входа CLI."""
+    parser = argparse.ArgumentParser(
+        description="Утилита для запуска этапов обработки данных"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("collect", help="Сбор данных из Prometheus")
+    subparsers.add_parser("preprocess", help="Предобработка собранных данных")
+    subparsers.add_parser("train", help="Обучение модели")
+    subparsers.add_parser("detect", help="Запуск realtime детектора")
+
+    args = parser.parse_args()
+
+    if args.command == "collect":
+        run_script("data_collector.py")
+    elif args.command == "preprocess":
+        run_script("preprocess_data.py")
+    elif args.command == "train":
+        run_script("train_autoencoder.py")
+    elif args.command == "detect":
+        run_script("realtime_detector.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,16 @@ The `config.yaml` file is central to running this project. Key sections include:
 
 ## Usage / Workflow
 
-The project follows a sequential workflow:
+The project follows a sequential workflow. Each stage can also be launched via the
+`cli.py` utility:
+```bash
+python cli.py collect       # сбор данных
+python cli.py preprocess    # предобработка
+python cli.py train         # обучение модели
+python cli.py detect        # запуск realtime детектора
+```
+
+The sequential workflow remains as follows:
 
 **Step 1: Data Collection (`data_collector.py`)**
 Collect historical data from your Prometheus instance.


### PR DESCRIPTION
## Summary
- add `cli.py` command line tool to run data collection, preprocessing, training or realtime detection
- document new CLI usage in README

## Testing
- `pipenv install --dev`

------
https://chatgpt.com/codex/tasks/task_e_6841cc8cb1c4832bb24b6e0589ee6e3f